### PR TITLE
Add useSentRequests hook

### DIFF
--- a/hooks/useSentRequests.ts
+++ b/hooks/useSentRequests.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react'
+import { supabase } from '@/lib/supabaseClient'
+
+export default function useSentRequests() {
+  const [requests, setRequests] = useState<any[]>([])
+
+  useEffect(() => {
+    const fetchRequests = async () => {
+      const { data: { user } } = await supabase.auth.getUser()
+      if (!user) return
+      const { data, error } = await supabase
+        .from('requests')
+        .select('*')
+        .eq('sender_id', user.id)
+      if (error) {
+        console.error(error)
+        return
+      }
+      if (data) {
+        setRequests(data)
+      }
+    }
+    fetchRequests()
+  }, [])
+
+  return requests
+}


### PR DESCRIPTION
## Summary
- add `useSentRequests` hook to fetch requests sent by the current user

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688856e124248329bf1100ad1238b123