### PR TITLE
Add hook for received requests

### DIFF
--- a/hooks/useReceivedRequests.ts
+++ b/hooks/useReceivedRequests.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react'
+import { supabase } from '@/lib/supabaseClient'
+
+export default function useReceivedRequests() {
+  const [data, setData] = useState<any[]>([])
+  const [error, setError] = useState<any>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const fetchRequests = async () => {
+      setLoading(true)
+      const { data: { user } } = await supabase.auth.getUser()
+      if (!user) {
+        setLoading(false)
+        return
+      }
+
+      const { data, error } = await supabase
+        .from('requests')
+        .select('*')
+        .eq('receiver_id', user.id)
+
+      if (error) {
+        setError(error)
+      } else if (data) {
+        setData(data)
+      }
+      setLoading(false)
+    }
+
+    fetchRequests()
+  }, [])
+
+  return { data, error, loading }
+}


### PR DESCRIPTION
## Summary
- add `useReceivedRequests` hook to fetch requests aimed at the logged-in user

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688857d7eee483299b29e13e29ce5b08