### PR TITLE
Fix subscription code for Supabase v2

### DIFF
--- a/app/requests/received/page.tsx
+++ b/app/requests/received/page.tsx
@@ -17,11 +17,22 @@ export default function ReceivedRequestsPage() {
   useEffect(() => {
     let subscription: any
     const subscribe = async () => {
-      const { data: { user } } = await supabase.auth.getUser()
+      const {
+        data: { user },
+      } = await supabase.auth.getUser()
       if (!user) return
       subscription = supabase
-        .from(`requests:receiver_id=eq.${user.id}`)
-        .on('INSERT', () => showToast('Nouvelle demande reçue'))
+        .channel('requests')
+        .on(
+          'postgres_changes',
+          {
+            event: 'INSERT',
+            schema: 'public',
+            table: 'requests',
+            filter: `receiver_id=eq.${user.id}`,
+          },
+          () => showToast('Nouvelle demande reçue')
+        )
         .subscribe()
     }
     subscribe()


### PR DESCRIPTION
## Summary
- fix Supabase realtime subscription on received requests page

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688865e707648329b5306df9db590131