### PR TITLE
Add login page and auth redirect

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,24 @@
+import SignInForm from '@/components/modal/signinForm'
+import { createServerComponentClient } from '@supabase/auth-helpers-nextjs'
+import { cookies } from 'next/headers'
+import { redirect } from 'next/navigation'
+
+export default async function LoginPage() {
+  const supabase = createServerComponentClient({ cookies })
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+
+  if (session) {
+    redirect('/profile')
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center p-4">
+      <h1 className="text-2xl font-bold mb-6">Connectez-vous</h1>
+      <div className="w-full max-w-md">
+        <SignInForm showModal={() => {}} />
+      </div>
+    </div>
+  )
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -5,8 +5,23 @@ import type { NextRequest } from 'next/server'
 
 export async function middleware(req: NextRequest) {
     const res = NextResponse.next()
-    // セッション（Cookie）を利用したAuthの管理が可能になる。
     const supabase = createMiddlewareClient({ req, res })
-    await supabase.auth.getSession()
+    const {
+        data: { session },
+    } = await supabase.auth.getSession()
+
+    const { pathname } = req.nextUrl
+
+    const isAuthPath =
+        pathname.startsWith('/login') ||
+        pathname.startsWith('/auth') ||
+        pathname.startsWith('/resetPassword')
+
+    if (!session && !isAuthPath && !pathname.startsWith('/_next') && pathname !== '/favicon.ico') {
+        const loginUrl = req.nextUrl.clone()
+        loginUrl.pathname = '/login'
+        return NextResponse.redirect(loginUrl)
+    }
+
     return res
 }


### PR DESCRIPTION
## Summary
- create `/login` page using existing sign-in form
- redirect unauthenticated users to `/login`

## Testing
- `npm run build` *(fails: `next` not found)*


------
https://chatgpt.com/codex/tasks/task_e_688868b039148329839a48c7f5c82ecd